### PR TITLE
Remove the unnecessary logic for setting the default value of opt

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -21,9 +21,7 @@ type FileServer struct {
 // NewFileServer initializes a FileServer.
 func NewFileServer(options ...Options) *FileServer {
 	var opt Options
-	if len(options) == 0 {
-		opt = Options{}
-	} else {
+	if len(options) > 0 {
 		opt = options[0]
 	}
 


### PR DESCRIPTION
Had an informative discussion about my understanding of variable shadowing and the uselessness of the initial logic for setting the default value of `opt`.