### PR TITLE
Stop documenting the port as ARG/ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,5 @@ USER serve
 
 VOLUME ["/var/www"]
 
-ARG PORT=8080
-ENV PORT $PORT
-
 CMD ["serve", "-dir", "/var/www"]
-
-EXPOSE $PORT
+EXPOSE 8080


### PR DESCRIPTION
I considered implementing it, but ultimately it's a huge hack for something people can just override themselves.