### PR TITLE
Enabled HTTP Basic Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ The following configuration options are available:
 * `--cert` path to the ssl cert file (defaults to `cert.pem`)
 * `--key` path to the ssl key file (defaults to `key.pem`)
 * `--dir` directory path to serve (defaults to `.`, also configurable by `arg[0]`)
+* `--users` path to users file (defaults to `users.dat`); file should contain lines of username:password in plain text
 
 ## Development
 

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -20,6 +20,7 @@ func main() {
 	flag.StringVar(&opt.CertFile, "cert", "cert.pem", "path to the ssl cert file")
 	flag.StringVar(&opt.KeyFile, "key", "key.pem", "path to the ssl key file")
 	flag.StringVar(&opt.Directory, "dir", "", "directory path to serve")
+	flag.StringVar(&opt.UsersFile, "users", "users.dat", "path to users file")
 	flag.Parse()
 
 	log := log.New(os.Stderr, "[serve] ", log.LstdFlags)

--- a/internal/commands/server_test.go
+++ b/internal/commands/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"log"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -73,4 +74,35 @@ func TestServerHTTPS(t *testing.T) {
 	assert.Contains(b.String(), "https server listening at")
 
 	getHTTPServerFunc = GetStdHTTPServer
+}
+
+func TestGetAuthUsers(t *testing.T) {
+	tests := []struct {
+		input  string
+		output map[string]string
+	}{
+		{ // Single user
+			"user1:pass1", map[string]string{
+				"user1": "pass1",
+			},
+		},
+		{ // Multiple users
+			"user1:pass1\nuser2:pass2", map[string]string{
+				"user1": "pass1",
+				"user2": "pass2",
+			},
+		},
+		{ // Empty file
+			"", map[string]string{},
+		},
+		{ // Incorrect structure
+			"user1:pass1:field1", map[string]string{},
+		},
+	}
+
+	for _, test := range tests {
+		mockFile := strings.NewReader(test.input)
+		assert.Equal(t, GetAuthUsers(mockFile), test.output)
+	}
+
 }

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -15,6 +15,7 @@ type Flags struct {
 	CertFile  string
 	KeyFile   string
 	Directory string
+	UsersFile string
 }
 
 // SanitizeDir allows a directory source to be set from multiple values. If any

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -1,0 +1,38 @@
+package middleware
+
+import "net/http"
+
+// Auth sets basic HTTP authorization
+func Auth(users map[string]string) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			// Only require auth if we have any users
+			if len(users) > 0 {
+				authUser, authPass, ok := r.BasicAuth()
+				if !ok {
+					// No username/password received
+					w.Header().Set("WWW-Authenticate", "Basic realm=Authenticate")
+					w.WriteHeader(http.StatusUnauthorized)
+				} else {
+					if pass, ok := users[authUser]; ok {
+						// User exists
+						if pass == authPass {
+							// Authentication successful
+							next.ServeHTTP(w, r)
+						} else {
+							http.Error(w, "Incorrect login details", http.StatusUnauthorized)
+							return
+						}
+					} else {
+						http.Error(w, "Incorrect login details", http.StatusUnauthorized)
+						return
+					}
+				}
+			} else {
+				next.ServeHTTP(w, r)
+			}
+		}
+
+		return http.HandlerFunc(fn)
+	}
+}

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -1,0 +1,55 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuth(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	req, err := http.NewRequest(http.MethodGet, "/", nil)
+	assert.NoError(err)
+	res := httptest.NewRecorder()
+
+	// No users
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	Auth(nil)(testHandler).ServeHTTP(res, req)
+	assert.Equal("", res.Header().Get("WWW-Authenticate"))
+
+	// Some users
+	testUsers := map[string]string{
+		"user1": "pass1",
+		"user2": "pass2",
+	}
+	Auth(testUsers)(testHandler).ServeHTTP(res, req)
+	assert.Equal("Basic realm=Authenticate", res.Header().Get("WWW-Authenticate"))
+	assert.Equal(http.StatusUnauthorized, res.Result().StatusCode)
+
+	// Correct password
+	// Recreate new environment
+	testHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	req, err = http.NewRequest(http.MethodGet, "/", nil)
+	assert.NoError(err)
+	res = httptest.NewRecorder()
+
+	req.SetBasicAuth("user1", "pass1")
+	Auth(testUsers)(testHandler).ServeHTTP(res, req)
+	assert.Equal("", res.Header().Get("WWW-Authenticate"))
+	assert.Equal(http.StatusOK, res.Result().StatusCode)
+
+	// Incorrect password
+	// Recreate new environment
+	testHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	req, err = http.NewRequest(http.MethodGet, "/", nil)
+	assert.NoError(err)
+	res = httptest.NewRecorder()
+
+	req.SetBasicAuth("user1", "pass2")
+	Auth(testUsers)(testHandler).ServeHTTP(res, req)
+	assert.Equal(http.StatusUnauthorized, res.Result().StatusCode)
+}


### PR DESCRIPTION
---
HTTP Basic Authentication
---

[contributing]: https://github.com/syntaqx/.github/blob/master/tree/.github/CONTRIBUTING.md

Hello! Thanks for your contribution! Please check and answer the following
questions before opening your pull request.

> **Please note:** that your PR will be closed without comment if you do not
> check the boxes above and provide ALL requested informtion.

- [X] Have you followed our [contributors guide][contributing]?
- [X] Why is this change being made? What value does it add?
_It adds HTTP Basic Authentication support._
- [X] Did you include automated testing where possible?
_Yes._
- [X] How can this be verified by a human? Describe how to test this.
_By default, server will try to retrieve users from users.dat file in username:password form, where each user is in its own line. Optionally, the path to file can be provided by -users parameter, as described in the help command._

Optionally, but if possible please also include any links relevant to your
changes. Issues, related PRs, URLs or other relevant resources are all useful.

_This is my first ever pull request on GitHub and I am still very, very new to Go. I would appreciate any negative as well as positive feedback. Thanks._